### PR TITLE
Fix default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Duplex } from 'stream';
 import { Runtime } from 'webextension-polyfill-ts';
 
-export default class PortDuplexStream extends Duplex {
+export = class PortDuplexStream extends Duplex {
   private _port: Runtime.Port;
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,4 +71,4 @@ export = class PortDuplexStream extends Duplex {
     }
     return cb();
   }
-}
+};


### PR DESCRIPTION
Fix export syntax such that `module.exports = PortDuplexStream` in `dist/index.js`.