### PR TITLE
fix: move webextension-polyfill-ts from devDeps to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "url": "https://github.com/MetaMask/extension-port-stream/issues"
   },
   "homepage": "https://github.com/MetaMask/extension-port-stream#readme",
-  "dependencies": {},
+  "dependencies": {
+    "webextension-polyfill-ts": "^0.22.0"
+  },
   "devDependencies": {
     "@metamask/eslint-config": "^4.1.0",
     "@types/node": "14.14.7",
@@ -39,7 +41,6 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-node": "^11.1.0",
-    "typescript": "^4.0.5",
-    "webextension-polyfill-ts": "^0.22.0"
+    "typescript": "^4.0.5"
   }
 }


### PR DESCRIPTION
fixes #10

See: https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

> Our package exposes declarations from each of those, so any user of our browserify-typescript-extension package needs to have these dependencies as well. For that reason, we used "dependencies" and not "devDependencies", because otherwise our consumers would have needed to manually install those packages. If we had just written a command line application and not expected our package to be used as a library, we might have used devDependencies.