### PR TITLE
Fix default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { Duplex } from 'stream';
 import { Runtime } from 'webextension-polyfill-ts';
 
-export = class PortDuplexStream extends Duplex {
+export default class PortDuplexStream extends Duplex {
   private _port: Runtime.Port;
 
   /**
@@ -70,4 +70,4 @@ export = class PortDuplexStream extends Duplex {
     }
     return cb();
   }
-};
+}


### PR DESCRIPTION
TypeScript expects us to use ES6-style exports rather than setting the exports on the `exports` object. Switching the export style fixes the resulting TypeScript types, ensuring that the default export is recognized as a class.

Fixes #7