### PR TITLE
change scheme of repository url to https in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/MetaMask/extension-port-stream.git"
+    "url": "https://git@github.com/MetaMask/extension-port-stream"
   },
   "keywords": [
     "WebExtension",


### PR DESCRIPTION
Despite being a valid url, the release action requires `https` scheme to be able to process releases: https://github.com/MetaMask/extension-port-stream/actions/runs/4852145037/jobs/8837832453 

```
Error: Error: process.env.REPOSITORY_URL must be a valid URL.
    at parseEnvironmentVariables (/home/runner/work/_actions/MetaMask/action-publish-release/v2/dist/index.js:10829:15)
    at getReleaseNotes (/home/runner/work/_actions/MetaMask/action-publish-release/v2/dist/index.js:10872:73)
```
This should unblock releases by changing the url scheme to https.
After this, release has to be reattempted for `v2.0.2` (#42)