### PR TITLE
fix(deps): move webextension-polyfill to peerDeps + devDeps 

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
     "webextension-polyfill": ">=0.10.0 <1.0"
   },
   "peerDependencies": {
-    "webextension-polyfill": ">=0.10.0 <1.0"
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "homepage": "https://github.com/MetaMask/extension-port-stream#readme",
   "dependencies": {
-    "readable-stream": "^3.6.2 || ^4.4.2",
-    "webextension-polyfill": ">=0.10.0 <1.0"
+    "readable-stream": "^3.6.2 || ^4.4.2"
   },
   "devDependencies": {
     "@metamask/eslint-config": "^4.1.0",
@@ -45,6 +44,10 @@
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-json": "^2.1.2",
     "eslint-plugin-node": "^11.1.0",
-    "typescript": "^4.0.5"
+    "typescript": "^4.0.5",
+    "webextension-polyfill": ">=0.10.0 <1.0"
+  },
+  "peerDependencies": {
+    "webextension-polyfill": ">=0.10.0 <1.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Duplex } from 'readable-stream';
-import { Runtime } from 'webextension-polyfill';
+import type { Runtime } from 'webextension-polyfill';
 
 type Log = (data: unknown, out: boolean) => void;
 


### PR DESCRIPTION
It is only used for one type import and assumed in environment. 

This removes the trim by changing to type-level import and changing from `dependencies` to `devDependencies`+`peerDependencies`.

Also restricts the range to known minors after discussion elsewhere.

### Related
- https://github.com/MetaMask/providers/pull/319