### PR TITLE
feat: Add named export of `PortDuplexStream`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -89,3 +89,5 @@ export default class PortDuplexStream extends Duplex {
     this._log = log;
   }
 }
+
+export { PortDuplexStream };


### PR DESCRIPTION
Adds a named export of `PortDuplexStream`, in addition to the existing default export of the same.