### PR TITLE
fix: gracefully end stream on port disconnect to prevent "Premature close" errors

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -654,7 +654,7 @@ describe('ExtensionPortStream', () => {
       await expect(bgDisconnect).resolves.toEqual(undefined);
       await expect(uiDisconnect).resolves.toEqual(undefined);
 
-      // Stream should be destroyed
+      // Streams should be destroyed
       expect(bgPortStream.destroyed).toBe(true);
       expect(uiPortStream.destroyed).toBe(true);
 
@@ -689,7 +689,7 @@ describe('ExtensionPortStream', () => {
       await expect(bgDisconnect).resolves.toEqual(undefined);
       await expect(uiDisconnect).resolves.toEqual(undefined);
 
-      // Stream should be destroyed
+      // Streams should be destroyed
       expect(bgPortStream.destroyed).toBe(true);
       expect(uiPortStream.destroyed).toBe(true);
 
@@ -728,7 +728,46 @@ describe('ExtensionPortStream', () => {
       await expect(bgDisconnect).resolves.toEqual(undefined);
       await expect(uiDisconnect).resolves.toEqual(undefined);
 
-      // Stream should be destroyed
+      // Streams should be destroyed
+      expect(bgPortStream.destroyed).toBe(true);
+      expect(uiPortStream.destroyed).toBe(true);
+
+      // Verify no errors were emitted
+      expect(bgPortErrors).toHaveLength(0);
+      expect(uiPortErrors).toHaveLength(0);
+    });
+
+    it('returns early in onDisconnect if stream is already destroyed', async () => {
+      const chunkSize = 1024;
+      const { bgPortStream, uiPortStream, uiPort } = init({ chunkSize });
+
+      const bgPortErrors: Error[] = [];
+      bgPortStream.on('error', (err: Error) => {
+        bgPortErrors.push(err);
+      });
+      const uiPortErrors: Error[] = [];
+      uiPortStream.on('error', (err: Error) => {
+        uiPortErrors.push(err);
+      });
+
+      // Simulate disconnections
+      const bgDisconnect = new Promise((resolve) => bgPortStream.on('close', resolve));
+      const uiDisconnect = new Promise((resolve) => uiPortStream.on('close', resolve));
+
+      // Destroy the stream BEFORE the port disconnects
+      bgPortStream.destroy();
+
+      // Verify stream is destroyed
+      expect(bgPortStream.destroyed).toBe(true);
+      expect(uiPortStream.destroyed).toBe(false);
+
+      // When one port disconnects, both streams should close gracefully, without throwing errors
+      uiPort.disconnect();
+
+      await expect(bgDisconnect).resolves.toEqual(undefined);
+      await expect(uiDisconnect).resolves.toEqual(undefined);
+
+      // Streams should be destroyed
       expect(bgPortStream.destroyed).toBe(true);
       expect(uiPortStream.destroyed).toBe(true);
 
@@ -781,7 +820,7 @@ describe('ExtensionPortStream', () => {
       await expect(bgDisconnect).resolves.toEqual(undefined);
       await expect(uiDisconnect).resolves.toEqual(undefined);
 
-      // Stream should be destroyed
+      // Streams should be destroyed
       expect(bgPortStream.destroyed).toBe(true);
       expect(uiPortStream.destroyed).toBe(true);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,13 @@ export class ExtensionPortStream extends Duplex {
   #onDisconnect = (_port: Runtime.Port) => {
     // Clean up, as we aren't going to receive any more messages
     this.#inFlight.clear();
+
+    // If already destroyed (e.g., by external code), nothing more to do.
+    // push(null) and end() are not safe on destroyed streams.
+    if (this.destroyed) {
+      return;
+    }
+
     // Gracefully end both sides of the duplex stream to avoid "Premature close" errors.
     // Signal EOF on readable side
     this.push(null);


### PR DESCRIPTION
## Description

This PR fixes a "Premature close" error that occurs when the browser port disconnects. 

### Problem

In v5.0.1, the `#onDisconnect` handler was changed to call `this.destroy()` without an error to provide cleaner stream cleanup (PR #82) and eliminate the "Port disconnected" error.

However, calling `destroy()` on a stream that hasn't been properly ended causes downstream `pipeline()` and `finished()` utilities to detect this as an abnormal termination, resulting in `ERR_STREAM_PREMATURE_CLOSE` ("Premature close") errors.

This effectively replaced the "Port disconnected" error with a "Premature close" error in MetaMask extension at application start.

### Solution

Gracefully end both sides of the duplex stream before destroying:

1. **`this.push(null)`** - Signal EOF on the readable side
2. **Wait for `writableFinished`** - Ensure the writable side has completely finished flushing
3. **`this.destroy()`** - Only called after the stream has properly ended, to emit the 'close' event and clean up resources

The fix handles two scenarios:
- **Stream already finished** (`writableFinished === true`): Safe to destroy immediately
- **Stream not finished**: Listen for both 'finish' (success) and 'error' (failure) events, then destroy

### Why listen for both 'finish' and 'error'?

When the port disconnects while there's buffered data being flushed, pending `_write` calls will fail because `postMessage` throws on a disconnected port. In Node.js streams, the 'finish' event is only emitted when all data is successfully flushed - if a write fails with an error, 'finish' is never emitted. By listening for both events, we ensure cleanup occurs in all scenarios.

## References

- https://github.com/MetaMask/metamask-extension/issues/26337
- https://github.com/MetaMask/metamask-extension/issues/35241




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gracefully ends both sides of `ExtensionPortStream` on port disconnect and adds comprehensive tests covering disconnect scenarios.
> 
> - **Core (`src/index.ts`)**
>   - Update `#onDisconnect` to gracefully close the duplex:
>     - Clear `#inFlight`, return early if `destroyed`.
>     - Signal EOF via `this.push(null)` and end writable side.
>     - If `writableFinished`, `destroy()` immediately; otherwise wait for `finish` or `error` then `destroy()`.
>     - Call `end()` if not already ended.
> - **Tests (`src/index.test.ts`)**
>   - Add disconnect test suite validating graceful closure without errors:
>     - Normal disconnect closes both streams.
>     - Disconnect after `stream.end()`.
>     - Disconnect after writable is finished.
>     - Early return when already `destroyed`.
>     - Race condition: skip `destroy` when already destroyed during `onComplete` handler.
>   - Assert no errors emitted and both streams become `destroyed`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a84a8d96ba1953ff88a767d4035088015dfeb2e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->