### PR TITLE
fix: correct a typo in error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export { CHUNK_SIZE } from './constants';
 export class ExtensionPortStream extends Duplex {
   static readonly ErrorMessages = [
     // used after 2025-11-13. see https://chromium-review.googlesource.com/c/chromium/src/+/7147681
-    'Message length exceeded maximum allowed length of 64MiB.',
+    'Message exceeded maximum allowed length of 64MiB.',
     // used before 2025-10-24. see https://source.chromium.org/chromium/chromium/src/+/main:extensions/renderer/api/messaging/messaging_util.cc;l=99;bpv=1;bpt=0;drc=6e12249bb20a2aaf40f8b115e2ea07627c13f144;dlc=c8490d20ef70d32273aa08940bf138d6096c54b5
     'Message length exceeded maximum allowed length.',
   ] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export { CHUNK_SIZE } from './constants';
 export class ExtensionPortStream extends Duplex {
   static readonly ErrorMessages = [
     // used after 2025-11-13. see https://chromium-review.googlesource.com/c/chromium/src/+/7147681
-    'Message exceeded maximum allowed length of 64MiB.',
+    'Message exceeded maximum allowed size of 64MiB.',
     // used before 2025-10-24. see https://source.chromium.org/chromium/chromium/src/+/main:extensions/renderer/api/messaging/messaging_util.cc;l=99;bpv=1;bpt=0;drc=6e12249bb20a2aaf40f8b115e2ea07627c13f144;dlc=c8490d20ef70d32273aa08940bf138d6096c54b5
     'Message length exceeded maximum allowed length.',
   ] as const;


### PR DESCRIPTION
for the record: i'm an idiot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string change used only for error matching; low risk aside from potentially affecting detection if Chrome’s message differs unexpectedly.
> 
> **Overview**
> Updates `ExtensionPortStream.ErrorMessages` to match Chromium’s newer oversize `postMessage` error text (`Message exceeded maximum allowed size of 64MiB.`), ensuring the “message too large” detection path still triggers chunking/event emission when Chrome’s wording changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9bebbe0818c48fc48881d3be916ba85770cd437. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->